### PR TITLE
프론트엔드와 백엔드 변수명 일부 매핑, 일부 기능 수정

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -42,7 +42,8 @@ const user1 = {
   isRegular: true,
   is_admin: false,
   is_staff: false,
-  fullname: '16기 와아이',
+  nTh: 16,
+  fullname: '와아이',
   phone_number: '010-0000-0000',
   student_number: '2000000000',
   username: 'kswcia',
@@ -67,7 +68,8 @@ const user2 = {
   isRegular: true,
   is_admin: false,
   is_staff: false,
-  fullname: '13기 송민준',
+  nTh: 13,
+  fullname: '송민준',
   phone_number: '010-0000-0000',
   student_number: '2000000000',
   username: 'eksrns22tp',
@@ -91,7 +93,8 @@ const user3 = {
   isRegular: true,
   is_admin: false,
   is_staff: false,
-  fullname: '18기 송나리',
+  nTh: 18,
+  fullname: '송나리',
   phone_number: '010-0000-0000',
   student_number: '2000000000',
   username: 'na06130',
@@ -114,7 +117,7 @@ export const getUser = () => (dispatch) => {
   request('GET', 'users/session', [])
   .then((r) => {
     console.log(r)
-    dispatch(setUser(r))
+    dispatch(setUser(r.data))
   })
   .catch((e) => {
     console.log(e)

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -28,7 +28,7 @@ class Comment extends Component {
                 content={<Namecard content={author} />}
                 placement="leftTop"
               >
-                <Link to={`/members/${nickname}`}> {nickname} </Link>
+                <Link to={`/members/${author.username}`}> {nickname} </Link>
               </Popover>
               {text}
             </p>

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -8,7 +8,8 @@ import { printTime } from '../policy'
 
 class Comment extends Component {
   render() {
-    const author = this.props.content.author.fullname
+    const author = this.props.content.author
+    const nickname = `${author.nTh}기 ${author.fullname}`
     const text = this.props.content.text
     const createdAt = this.props.content.createdAt
     const recomments = this.props.content.recomments
@@ -24,10 +25,10 @@ class Comment extends Component {
           <div style={{ width: '91%' }}>
             <p>
               <Popover
-                content={<Namecard content={this.props.content.author} />}
+                content={<Namecard content={author} />}
                 placement="leftTop"
               >
-                <Link to={`/members/${author}`}> {author} </Link>
+                <Link to={`/members/${nickname}`}> {nickname} </Link>
               </Popover>
               {text}
             </p>

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -22,11 +22,12 @@ class Doc extends Component {
   render() {
     const isAppending = this.state.isAppending
     const content = this.props.content
-    const author = content.author.fullname
+    const author = content.author
+    const nickname = `${author.nTh}기 ${author.fullname}`
     const text = content.text
     const createdAt = content.createdAt
-    const imgsrc = content.author.profileImage.savedPath
-    const imgalt = content.author.profileImage.filename
+    const imgsrc = author.profileImage.savedPath
+    const imgalt = author.profileImage.filename
     const images = content.images
     const user = this.props.user
     return (
@@ -55,9 +56,9 @@ class Doc extends Component {
             <div style={{ fontSize: '14pt' }}>
               <Popover
                 placement="leftTop"
-                content={<Namecard content={content.author} />}
+                content={<Namecard content={author} />}
               >
-                <Link to={`/members/${author}`}> {author} </Link>
+                <Link to={`/members/${nickname}`}> {nickname} </Link>
               </Popover>
             </div>
             <div> {printTime(createdAt)} </div>

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -58,7 +58,7 @@ class Doc extends Component {
                 placement="leftTop"
                 content={<Namecard content={author} />}
               >
-                <Link to={`/members/${nickname}`}> {nickname} </Link>
+                <Link to={`/members/${author.username}`}> {nickname} </Link>
               </Popover>
             </div>
             <div> {printTime(createdAt)} </div>

--- a/src/components/Namecard.js
+++ b/src/components/Namecard.js
@@ -6,6 +6,7 @@ class Namecard extends Component {
   render() {
     let cwidth = '320px'  // component width
     const user = this.props.content
+    const nickname = `${user.nTh}기 ${user.fullname}`
     cwidth = this.props.width
     return (
       <div style={{ width: cwidth }}>
@@ -21,7 +22,7 @@ class Namecard extends Component {
           <div style={{ fontSize: '18pt', textAlign: 'left' }}>
             <div style={{ height: '34%', fontWeight: 'bold' }} >
               <Link to={`/members/${user.username}`}>
-                {user.fullname}
+                {nickname}
               </Link>
             </div>
             <div style={{ height: '33%', fontSize: '14pt' }}>

--- a/src/components/Noti.js
+++ b/src/components/Noti.js
@@ -8,6 +8,7 @@ import { printTime } from '../policy'
 class Noti extends Component {
   render() {
     const noti = this.props.content
+    const nickname = `${noti.from.nTh}기 ${noti.from.fullname}`
     return (
       <div key={noti.id}>
         <div
@@ -37,7 +38,7 @@ class Noti extends Component {
                   placement="leftTop"
                   content={<Namecard content={noti.from} />}
                 >
-                  <a href="#"> {noti.from.fullname}</a>
+                  <a href="#"> {nickname}</a>
                 </Popover>
               </div>
               <div style={{ color: 'rgba(1,1,1,0.5)' }}> {printTime(noti.createdAt)} </div>

--- a/src/components/Recomment.js
+++ b/src/components/Recomment.js
@@ -6,10 +6,11 @@ import Namecard from './Namecard'
 class Recomment extends Component {
   render() {
     const content = this.props.content
-    const author = content.author.fullname
+    const author = content.author
+    const nickname = `${author.nTh}기 ${author.fullname}`
     const text = content.text
-    const imgsrc = content.author.profileImage.savedPath
-    const imgalt = content.author.profileImage.filename
+    const imgsrc = author.profileImage.savedPath
+    const imgalt = author.profileImage.filename
     return (
       <div style={{ margin: '2px 0px' }} >
         <div style={{ display: 'flex' }} >
@@ -19,10 +20,10 @@ class Recomment extends Component {
           <div style={{ width: '91%' }}>
             <p>
               <Popover
-                content={<Namecard content={content.author} />}
+                content={<Namecard content={author} />}
                 placement="leftTop"
               >
-                <a> {author} </a>
+                <a> {nickname} </a>
               </Popover>
               {text}
             </p>

--- a/src/components/Write.js
+++ b/src/components/Write.js
@@ -25,6 +25,7 @@ class Write extends Component {
   onClickMethod() {
     args.push({ type: 'String', key: 'text', value: this.state.text })
     request('POST', 'documents', args)
+    this.setState({ text: '', mode: 'edit' })
   }
   render() {
     const text = this.state.text

--- a/src/container/Doorlock.js
+++ b/src/container/Doorlock.js
@@ -12,7 +12,7 @@ class Doorlock extends Component {
     }
   }
   verify() {
-    if (this.props.user.user.isRegularMember) {
+    if (this.props.user.isRegular) {
       this.setState({ mode: 'Regular' })
     } else {
       this.setState({ mode: 'Ilregular' })

--- a/src/container/Members.js
+++ b/src/container/Members.js
@@ -47,7 +47,7 @@ class Members extends Component {
               <div style={{ display: 'flex', flexWrap: 'wrap' }}>
                 {this.props.members
                   .filter(member =>
-                      member.last_name.includes(filter) ||
+                      member.fullname.includes(filter) ||
                       member.username.includes(filter))
                   .map(member =>
                   (<div key={member.id} style={{ margin: '8px', padding: '8px', border: 'solid 1px #76c2ff', borderRadius: '4px' }}>
@@ -60,7 +60,7 @@ class Members extends Component {
               {this.props.members
                 .filter(member =>
                     member.isActive &&
-                     (member.last_name.includes(filter) ||
+                     (member.fullname.includes(filter) ||
                       member.username.includes(filter)))
                 .map(member =>
                 (<div key={member.id} style={{ margin: '8px', padding: '8px', border: 'solid 1px #76c2ff', borderRadius: '4px' }}>

--- a/src/container/Members.js
+++ b/src/container/Members.js
@@ -57,16 +57,18 @@ class Members extends Component {
               </div>
             </TabPane>
             <TabPane tab="활동인구" key="act">
-              {this.props.members
-                .filter(member =>
-                    member.isActive &&
-                     (member.fullname.includes(filter) ||
-                      member.username.includes(filter)))
-                .map(member =>
-                (<div key={member.id} style={{ margin: '8px', padding: '8px', border: 'solid 1px #76c2ff', borderRadius: '4px' }}>
-                  <Namecard content={member} width="240px" />
-                </div>),
-                )}
+              <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+                {this.props.members
+                  .filter(member =>
+                      member.isActive &&
+                      (member.fullname.includes(filter) ||
+                        member.username.includes(filter)))
+                  .map(member =>
+                  (<div key={member.id} style={{ margin: '8px', padding: '8px', border: 'solid 1px #76c2ff', borderRadius: '4px' }}>
+                    <Namecard content={member} width="240px" />
+                  </div>),
+                  )}
+              </div>
             </TabPane>
           </Tabs>
         }

--- a/src/container/Sider.js
+++ b/src/container/Sider.js
@@ -58,7 +58,11 @@ class Sider extends Component {
       >
         {user.has_logged_in ?
           <div style={{ height: '240px', overflow: 'hidden' }}>
-            <img src={user.user.image.src} alt={user.user.image.alt} width="100%" />
+            <img
+              src={user.profileImage.savedPath}
+              alt={user.profileImage.filename}
+              width="100%"
+            />
           </div> :
           <div style={{ height: '240px', background: 'black' }} />
         }

--- a/src/container/Sider.js
+++ b/src/container/Sider.js
@@ -101,17 +101,20 @@ class Sider extends Component {
           <Menu.Item key="/old/texts"> (구) 자유</Menu.Item>
           */}
         </SubMenu>
-        <SubMenu
-          key="sub6"
-          title={
-            <span><Icon type="tool" /><span>임원진도구</span></span>}
-        >
-          <Menu.Item key="/deactivate">활동인구초기화</Menu.Item>
-        </SubMenu>
+        {
+          user.is_admin ?
+            <SubMenu
+              key="sub6"
+              title={<span><Icon type="tool" /><span>임원진 도구</span></span>}
+            >
+              <Menu.Item key="/deactivate">활동인구 초기화</Menu.Item>
+            </SubMenu>
+          :
+            <div />
+        }
         <SubMenu
           key="sub7"
-          title={
-            <span><Icon type="frown" /><span>로그아웃</span></span>}
+          title={<span><Icon type="frown" /><span>로그아웃</span></span>}
         >
           <Menu.Item key="/logout">로그아웃</Menu.Item>
         </SubMenu>

--- a/src/container/Userpage.js
+++ b/src/container/Userpage.js
@@ -55,8 +55,8 @@ class Userpage extends Component {
                 {member.length > 0 &&
                   <div className="my-inform-value">
                     <ol>
-                      <li>{member[0].last_name}</li>
-                      <li>{member[0].last_name}</li>
+                      <li>{`${member[0].nTh}기`}</li>
+                      <li>{member[0].fullname}</li>
                       <li>{member[0].student_number}</li>
                       <li>{member[0].department}</li>
                       <li>{Userpage.check(member[0].isActivated)}</li>


### PR DESCRIPTION
Fixes # .

이 풀리퀘스트로 바뀌는 것  
- 백엔드에 맞춰 기수와 이름을 분리했습니다.
- 타임라인에서 게시글 및 댓글 작성자를 클릭할 때, 잘못된 링크로 이동하던 문제를 수정했습니다.
- 이제 임원진 메뉴는 임원진만 볼 수 있습니다.
- 글을 작성하고 나면 다시 글을 쓸 수 있도록 초기화됩니다.
- 회원들 메뉴에서 모든회원 대비 활동인구의 탭이 가로로 길게 나오던 부분을 수정했습니다.

@kswgit @cocoapi @songnari @sGOM 
