### PR TITLE
멤버 불러오기, 좋아요, 유저 페이지 수정

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -54,6 +54,7 @@ const user1 = {
   },
 }
 
+/*
 const user2 = {
   id: 2,
   date_joined: '2017-02-14T03:41:33.603865Z',
@@ -104,13 +105,14 @@ const user3 = {
     filename: '리_profile.png',
   },
 }
+*/
 
 export const getMembers = () => (dispatch) => {
-  dispatch(setMembers([
-    user1,
-    user2,
-    user3,
-  ]))
+  request('GET', 'users', [])
+  .then((r) => {
+    dispatch(setMembers(r.data))
+  })
+  .catch()
 }
 
 export const getUser = () => (dispatch) => {

--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -38,11 +38,15 @@ class Comments extends Component {
           <Icon type="like" style={{ paddingRight: '4px' }} />
           <Popover
             content={
+              feed.likedBy.length ?
               feed.likedBy.map(lover => (
                 <pre>
                   {`${lover.nTh}기 ${lover.fullname}`}
                 </pre>
-              ))
+              )) :
+              <pre>
+                당신이 이 글의 첫 번째 좋아요를 눌러주세요!
+              </pre>
             }
             placement="rightTop"
           >

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -113,7 +113,7 @@ class Doc extends Component {
               size="small"
               onClick={() => this.onClickLikeIt()}
             />
-            <a>
+            <a onClick={() => this.onClickLikeIt()}>
               좋아요
             </a>
           </div>

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -86,12 +86,16 @@ class Doc extends Component {
           </div>
           <div style={{ flexGrow: 2 }} >
             <div style={{ fontSize: '14pt' }}>
-              <Popover
-                placement="leftTop"
-                content={<Namecard content={author} />}
-              >
-                <Link to={`/members/${author.username}`}> {nickname} </Link>
-              </Popover>
+              {
+                author.nTh ?
+                  <Popover
+                    placement="leftTop"
+                    content={<Namecard content={author} />}
+                  >
+                    <Link to={`/members/${author.username}`}> {nickname} </Link>
+                  </Popover>
+                : <div> 탈퇴한 회원 </div>
+              }
             </div>
             <div> {printTime(createdAt)} </div>
           </div>

--- a/src/container/Doorlock.js
+++ b/src/container/Doorlock.js
@@ -15,7 +15,7 @@ class Doorlock extends Component {
     if (this.props.user.isRegular) {
       this.setState({ mode: 'Regular' })
     } else {
-      this.setState({ mode: 'Ilregular' })
+      this.setState({ mode: 'Irregular' })
     }
   }
   render() {

--- a/src/container/Portal.js
+++ b/src/container/Portal.js
@@ -23,7 +23,7 @@ class Portal extends Component {
           </aside>
         </Col>
         <Col span={12}>
-          <Timeline onLikeIt={() => this.onLikeIt()} />
+          <Timeline onLikeIt={() => this.onLikeIt()} redraw={this.state.redraw} />
         </Col>
         <Col span={6}>
           <Affix offsetTop={52}>

--- a/src/container/Sider.js
+++ b/src/container/Sider.js
@@ -69,7 +69,7 @@ class Sider extends Component {
           <div style={{ height: '240px', background: 'black' }} /> */
         }
         {
-          user.isRegular ||
+          user.isActivated ||
           <SubMenu
             key="sub1"
             title={

--- a/src/container/Sider.js
+++ b/src/container/Sider.js
@@ -68,14 +68,17 @@ class Sider extends Component {
           this.props.getUser() /* :
           <div style={{ height: '240px', background: 'black' }} /> */
         }
+        {
+          user.isRegular ||
+          <SubMenu
+            key="sub1"
+            title={
+              <span><Icon type="appstore" /><span>대시보드</span></span>}
+          >
+            <Menu.Item key="/dashboard">대시보드</Menu.Item>
+          </SubMenu>
+        }
         {/* 배포후 패치해도 되는 내용
-        <SubMenu
-          key="sub1"
-          title={
-            <span><Icon type="appstore" /><span>대시보드</span></span>}
-        >
-          <Menu.Item key="/dashboard">대시보드</Menu.Item>
-        </SubMenu>
         <SubMenu
           key="sub2"
           title={
@@ -108,15 +111,13 @@ class Sider extends Component {
           */}
         </SubMenu>
         {
-          user.isSuperUser ?
-            <SubMenu
-              key="sub6"
-              title={<span><Icon type="tool" /><span>임원진 도구</span></span>}
-            >
-              <Menu.Item key="/deactivate">활동인구 초기화</Menu.Item>
-            </SubMenu>
-          :
-            <div />
+          user.isSuperUser &&
+          <SubMenu
+            key="sub6"
+            title={<span><Icon type="tool" /><span>임원진 도구</span></span>}
+          >
+            <Menu.Item key="/deactivate">활동인구 초기화</Menu.Item>
+          </SubMenu>
         }
         <SubMenu
           key="sub7"

--- a/src/container/Timeline.js
+++ b/src/container/Timeline.js
@@ -12,6 +12,7 @@ class Timeline extends Component {
     super(props)
     this.state = {
       response: '',
+      redraw: false,
     }
   }
   componentWillMount() {
@@ -23,6 +24,12 @@ class Timeline extends Component {
       this.props.getUser()
     }
     */
+  }
+  componentWillReceiveProps(newProps) {
+    if (newProps.redraw !== this.state.redraw) {
+      this.props.getTimeline()
+      this.setState({ redraw: newProps.redraw })
+    }
   }
   writeComplete() {
     request('GET', 'documents', [])

--- a/src/container/Userpage.js
+++ b/src/container/Userpage.js
@@ -15,6 +15,7 @@ class Userpage extends Component {
     this.props.getMembers()
   }
   render() {
+    // 유저 페이지 넘길 때, props로 유저 아이디 넘기면 좋을 듯합니다
     const members = this.props.members
     const username = this.props.match.params.username
     const member = members.length > 0 ? members.filter(m => m.username === username) : []
@@ -27,8 +28,8 @@ class Userpage extends Component {
             </div>
           </div>
           <div className="menu-bar">
-            <div className="menu"><a href="">내가쓴글</a></div>
-            <div className="menu"><a href="">좋아요 누른글</a></div>
+            <div className="menu"><a href="">작성한 글</a></div>
+            <div className="menu"><a href="">좋아요한 글</a></div>
             <div className="menu"><a href="">댓글단 글</a></div>
             <div className="menu last"><a href="/members">회원들</a></div>
             <div className="blank" />
@@ -40,7 +41,7 @@ class Userpage extends Component {
         <div className="under-board">
           <div className="my-inform-size">
             <div className="my-inform-board">
-              <div className="my-inform-title"><Icon type="user" /> 내 정보</div>
+              <div className="my-inform-title"><Icon type="user" /> 유저 정보</div>
               <div className="my-inform-content">
                 <div className="my-inform-key">
                   <ol>
@@ -55,12 +56,12 @@ class Userpage extends Component {
                 {member.length > 0 &&
                   <div className="my-inform-value">
                     <ol>
-                      <li>{`${member[0].nTh}기`}</li>
+                      <li>{member[0].nTh}기</li>
                       <li>{member[0].fullname}</li>
-                      <li>{member[0].student_number}</li>
+                      <li>{member[0].studentNumber}</li>
                       <li>{member[0].department}</li>
                       <li>{Userpage.check(member[0].isActivated)}</li>
-                      <li>{Userpage.check(member[0].isRegularMember)}</li>
+                      <li>{Userpage.check(member[0].isRegular)}</li>
                     </ol>
                   </div>
                 }
@@ -69,7 +70,7 @@ class Userpage extends Component {
           </div>
           <div className="my-write-size">
             <div className="my-write-title">
-              <Icon type="edit" /> 내가 쓴글
+              <Icon type="edit" /> 작성한 글
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', padding: '12px' }}>
               <div style={{ display: 'block' }}>


### PR DESCRIPTION
Fixes # .

이 풀리퀘스트로 바뀌는 것  
- getMembers를 DB 데이터로 불러옵니다.
- 좋아요 0개면 메시지가 나타납니다.
- 좋아요 글자를 눌러도 좋아요가 추가됩니다.
- 기수가 0이면 탈퇴한 회원으로 표시됩니다.
- 불필요한 부분, 수정 필요한 부분을 주석에 추가했습니다.
- 유저 페이지의 일부 텍스트와 변수명을 수정했습니다.
- 일부 오타 수정했습니다.
- 댓글 좋아요, 대댓글 개수를 db 데이터에서 불러옵니다.

@kswgit
