### PR TITLE
https 적용 및 타임라인 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
       "<rootDir>[/\\\\](build|docs|node_modules|scripts)[/\\\\]"
     ],
     "testEnvironment": "node",
-    "testURL": "http://localhost",
+    "testURL": "https://localhost",
     "transform": {
       "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest",
       "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",

--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -4,9 +4,6 @@ import Comment from './Comment'
 import PostComment from './PostComment'
 import Line from './Line'
 
-const Icon = require('antd/lib/icon')
-const Popover = require('antd/lib/popover')
-
 class Comments extends Component {
   render() {
     const comments = this.props.content
@@ -17,27 +14,6 @@ class Comments extends Component {
         background: '#fff', display: 'flex', flexDirection: 'column', padding: '8px', overflow: 'hidden',
       }}
       >
-        <div>
-          <Icon type="like" style={{ paddingRight: '4px' }} />
-          <Popover
-            content={
-              feed.likedUsers.length
-                ? feed.likedUsers.map((lover, idx) => (
-                  <pre key={idx}>
-                  {`${lover.nTh}기 ${lover.fullname}`}
-                  </pre>
-                ))
-                : (
-                  <pre>
-                    당신이 이 글의 첫 번째 좋아요를 눌러주세요!
-                  </pre>
-                )
-            }
-            placement="rightTop"
-          >
-            <a> {` ${feed.likedUsers.length} `} </a>
-          </Popover>
-        </div>
         <Line />
         {comments.map((comment) => (
           <Comment

--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -14,7 +14,6 @@ class Comments extends Component {
         background: '#fff', display: 'flex', flexDirection: 'column', padding: '8px', overflow: 'hidden',
       }}
       >
-        <Line />
         {comments.map((comment) => (
           <Comment
             key={comment.id}

--- a/src/components/Comments.js
+++ b/src/components/Comments.js
@@ -7,7 +7,6 @@ import Line from './Line'
 class Comments extends Component {
   render() {
     const comments = this.props.content
-    const { feed } = this.props
     const { user } = this.props
     return (
       <div style={{

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -50,16 +50,12 @@ class Doc extends Component {
     const { user } = this.props
     return (
       <div style={{ background: '#fff', padding: '8px', marginBottom: '1px' }}>
-        <div style={{ display: 'flex', lineHeight: '16pt', marginBottom: '4px' }}>
-          <div>
-            여기는 뭘 넣으면 예쁠까?
-          </div>
+        {/* <div style={{ display: 'flex', lineHeight: '16pt', marginBottom: '4px' }}>
+          <h2>{content.title}</h2>
           <div style={{ flexGrow: 2 }} />
-          <div>
-            <Button shape="circle" icon="down" size="small" />
-          </div>
+          <Button shape="circle" icon="down" size="small" />
         </div>
-        <Line />
+        <Line /> */}
         <div style={{ display: 'flex', marginTop: '4px' }}>
           <div style={{
             width: '48px',

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -17,7 +17,7 @@ class Doc extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      isAppending: true,
+      isAppend: true,
     }
     this.props.getUser()
   }
@@ -35,11 +35,11 @@ class Doc extends Component {
   }
 
   toggleAppending() {
-    this.setState({ isAppending: !this.state.isAppending })
+    this.setState({ isAppend: !this.state.isAppend })
   }
 
   render() {
-    const { isAppending } = this.state
+    const { isAppend } = this.state
     const { content } = this.props
     const { author } = content
     const nickname = `${author.nTh}기 ${author.fullname}`
@@ -97,10 +97,11 @@ class Doc extends Component {
           <ReactMarkdown source={content.content} />
         </div>
         { /* <Album content={images} height="320px" /> */ }
-        <div style={isAppending ? { display: 'block' } : { display: 'none' }}>
+        <div style={isAppend ? { display: 'block' } : { display: 'none' }}>
           <Write
             user={user}
             documentId={this.props.content.id}
+            isAppend
           />
         </div>
         <Line />

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -108,17 +108,34 @@ class Doc extends Component {
         </div>
         <Line />
         <div style={{ marginTop: '4px', display: 'flex' }}>
-          <div style={{ marginRight: '4px' }}>
-            <Button
-              style={{ marginRight: '4px' }}
-              shape="circle"
-              icon="like"
-              size="small"
-              onClick={() => this.onClickLikeIt()}
-            />
-            <a onClick={() => this.onClickLikeIt()}>
-              좋아요
-            </a>
+          <div style={{ marginRight: '12px' }}>
+            <Popover
+              content={
+                content.likedUsers.length
+                  ? content.likedUsers.map((lover, idx) => (
+                    <pre key={idx}>
+                    {`${lover.nTh}기 ${lover.fullname}`}
+                    </pre>
+                  ))
+                  : (
+                    <pre>
+                      당신이 이 글의 첫 번째 좋아요를 눌러주세요!
+                    </pre>
+                  )
+              }
+              placement="rightTop"
+            >
+              <Button
+                style={{ marginRight: '4px' }}
+                shape="circle"
+                icon="like"
+                size="small"
+                onClick={() => this.onClickLikeIt()}
+              />
+              <a onClick={() => this.onClickLikeIt()}>
+                {`좋아요 ${content.likedUsers.length}`}
+              </a>
+            </Popover>
           </div>
           <div style={{ marginRight: '4px' }}>
             <Button

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -17,7 +17,7 @@ class Doc extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      isAppend: true,
+      isAppend: false,
     }
     this.props.getUser()
   }

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -19,6 +19,7 @@ class Doc extends Component {
     this.state = {
       isAppending: false,
     }
+    this.props.getUser()
   }
 
   onClickLikeIt() {
@@ -149,6 +150,8 @@ class Doc extends Component {
               {`댓글 ${content.comments.length}`}
             </a>
           </div>
+          {content.author.id === this.props.user.id
+          ? 
           <div>
             <Button
               style={{ marginRight: '4px' }}
@@ -161,6 +164,8 @@ class Doc extends Component {
               이어쓰기
             </a>
           </div>
+          : <div />
+          }
         </div>
       </div>
     )

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -17,7 +17,7 @@ class Doc extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      isAppending: false,
+      isAppending: true,
     }
     this.props.getUser()
   }

--- a/src/components/Doc.js
+++ b/src/components/Doc.js
@@ -137,7 +137,7 @@ class Doc extends Component {
               </a>
             </Popover>
           </div>
-          <div style={{ marginRight: '4px' }}>
+          <div style={{ marginRight: '12px' }}>
             <Button
               style={{ marginRight: '4px' }}
               shape="circle"
@@ -146,7 +146,7 @@ class Doc extends Component {
               onClick={() => this.props.onClickComments()}
             />
             <a onClick={() => this.props.onClickComments()}>
-              댓글
+              {`댓글 ${content.comments.length}`}
             </a>
           </div>
           <div>

--- a/src/components/Feed.js
+++ b/src/components/Feed.js
@@ -7,7 +7,7 @@ class Feed extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      viewComments: false,
+      viewComments: true,
     }
   }
 

--- a/src/components/PostComment.js
+++ b/src/components/PostComment.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import koKR from 'antd/lib/locale-provider/ko_KR'
 import { postComment } from '../actions'
 
-const Input = require('antd/lib/input')
+const Mention = require('antd/lib/mention')
 const Button = require('antd/lib/button')
 const LocaleProvider = require('antd/lib/locale-provider')
 
@@ -12,25 +12,26 @@ class PostComment extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      text: '',
+      content: '',
     };
   }
 
   onButtonClicked() {
     this.props.postComment({
       documentId: this.props.feedId,
-      text: this.state.text,
+      content: this.state.content,
     })
-    this.setState({ text: '' })
+    this.setState({ content: '' })
   }
 
-  onChangeInput(e) {
-    this.setState(e);
+  onChangeInput(editorState) {
+    const { toString } = Mention
+    const content = toString(editorState).replace(/(?=.*(?<!  \n)$)(?=\n$)/, '  \n')
+    this.setState({ content })
   }
 
   render() {
     const { user } = this.props
-    const { text } = this.state
     return (
       <LocaleProvider locale={koKR}>
         <div style={{ display: 'flex' }}>
@@ -46,12 +47,11 @@ class PostComment extends Component {
           }}
           >
             <div style={{ width: '94%', marginRight: '4px' }}>
-              <Input
-                type="textarea"
-                autosize={{ minRows: 1 }}
-                onChange={(e) => this.onChangeInput({ text: e.target.value })}
+              <Mention
+                style={{ width: '100%', height: '30px' }}
+                onChange={(editorState) => this.onChangeInput(editorState)}
                 placeholder="Write Comment"
-                value={text}
+                multiLines
               />
             </div>
             <div>

--- a/src/components/Write.js
+++ b/src/components/Write.js
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import { patchDocument, postDocument } from '../actions'
 
 const Button = require('antd/lib/button')
-const Input = require('antd/lib/input')
+const Mention = require('antd/lib/mention')
 const notification = require('antd/lib/notification')
 
 const openNotificationWithIcon = () => {
@@ -26,18 +26,22 @@ class Write extends Component {
     })
   }
 
+  onEditorChange(editorState) {
+    const { toString } = Mention
+    const content = toString(editorState).replace(/(?=.*(?<!  \n)$)(?=\n$)/, '  \n')
+    this.setState({ content })
+  }
+
   getDisplay(mode, content) {
-    const editModeDisplay = (content) => (
-      <Input
-        type="textarea"
-        autosize={{ minRows: 4 }}
-        style={{ width: '100%' }}
-        value={content}
-        onChange={(e) => this.setState({ content: e.target.value })}
+    const editModeDisplay = (
+      <Mention
+        style={{ width: '100%', height: '100px' }}
+        onChange={(editorState) => this.onEditorChange(editorState)}
+        multiLines
       />
     )
     const previewModeDisplay = (content) => (<ReactMarkdown source={content} />)
-    if (mode === 'edit') return editModeDisplay(content)
+    if (mode === 'edit') return editModeDisplay
     if (mode === 'preview') return previewModeDisplay(content)
     return <div />
   }

--- a/src/components/Write.js
+++ b/src/components/Write.js
@@ -90,7 +90,7 @@ class Write extends Component {
   render() {
     const { content } = this.state
     const { mode } = this.state
-    const { user } = this.props
+    const { user, isAppend } = this.props
 
     const display = this.getDisplay(mode, content)
     const button = this.getButton(mode)
@@ -100,12 +100,17 @@ class Write extends Component {
         marginBottom: '4px', padding: '4px', display: 'flex', background: '#FFF',
       }}
       >
-        <div style={{
-          marginRight: '4px', width: '48px', height: '48px', background: '#FFF', overflow: 'hidden',
-        }}
-        >
-          <img src={user.profileImage.savedPath} alt={user.profileImage.filename} width="100%" />
-        </div>
+        {
+          isAppend
+          || (
+            <div style={{
+              marginRight: '4px', width: '48px', height: '48px', background: '#FFF', overflow: 'hidden',
+            }}
+            >
+              <img src={user.profileImage.savedPath} alt={user.profileImage.filename} width="100%" />
+            </div>
+          )
+        }
         <div style={{ flexGrow: 1 }}>
           { display }
           <div style={{ justifyContent: 'space-between', display: 'flex', margin: '4px 0px' }}>

--- a/src/fetches/axios.js
+++ b/src/fetches/axios.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 // const host = 'https://cia.kw.ac.kr/api/'
 
 export default axios.create({
-  baseURL: 'http://localhost/api',
+  baseURL: 'https://localhost/api',
   Headers: {
     withCredentials: true
   }


### PR DESCRIPTION
Fixes #123, #130 .


이 풀리퀘스트로 바뀌는 것  
- 프론트엔드와 백엔드 모두 https 주소를 사용합니다.
- 기존 '여기는 뭘 넣어야 이쁠까' 부분을 삭제했습니다.
- 좋아요 수, 댓글 수를 버튼 바로 오른쪽에 표시합니다.
- 이어쓰기 버튼은 자기 글인 경우에만 표시합니다.
- 이제 기본적으로 댓글창을 표시합니다.
- 글쓰기, 댓글쓰기 창 크기가 제한 없이 변경되던 부분을 수정했습니다.
- 더 이상 이어쓰기에 프로필 사진을 표시하지 않습니다.

@droplet92
