### PR TITLE
CI를 위해 빌드 설정 수정

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -67,7 +67,7 @@ function build(previousFileSizes) {
       process.exit(1);
     }
 
-    if (process.env.CI && stats.compilation.warnings.length) {
+    if (process.env.CI && process.env.CI.toLowerCase() !== 'false' && stats.compilation.warnings.length) {
       printErrors('Failed to compile. When process.env.CI = true, warnings are treated as failures. Most CI servers set this automatically.', stats.compilation.warnings);
       process.exit(1);
     }


### PR DESCRIPTION
Fixes # .

이 풀리퀘스트로 바뀌는 것  
- 빌드 옵션에서 process.env.CI가 false인 경우 에러 띄우지 않음
관련: https://github.com/facebook/create-react-app/commit/5b38c5439d9f078cbb65e3f9c6ae86cb6f9d7097

@droplet92
